### PR TITLE
Fix remove_object_hook example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ new Foo();
 
 // Somewhere else...
 Inpsyde\remove_object_hook('init', Foo::class, 'init');
-Inpsyde\remove_object_hook('init', Foo::class, 'init', removeStaticCallbacks: true);
+Inpsyde\remove_object_hook('template_redirect', Foo::class, 'templateRedirect', removeStaticCallbacks: true);
 ```
 
 


### PR DESCRIPTION
@gmazzap It was impossible to understand, both removals were for `init`.